### PR TITLE
spesify the numpy version

### DIFF
--- a/fall_2022/requirements.txt
+++ b/fall_2022/requirements.txt
@@ -22,7 +22,7 @@ nbconvert
 nbformat==5.0.7
 networkx==2.5
 notebook
-numpy
+numpy==1.19
 olefile==0.46
 pandocfilters==1.4.2
 pexpect==4.8.0


### PR DESCRIPTION
To avoid future package incompatible issues. When installed numpy 1.23.3 rather than 1.19 will cause error with importing numpy multiarray package.